### PR TITLE
refactor: make server script 개선

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # 기본 실행 타겟
 run-server: run-localstack run-mariadb copy-config run-springboot
+restart-server: stop-springboot run-springboot
 debug-server: run-localstack run-mariadb copy-config debug-springboot
 stop-server: stop-localstack stop-mariadb stop-springboot
 clean-server: rm-localstack rm-mariadb clean-gradle

--- a/scripts/server/debug-springboot-trace.sh
+++ b/scripts/server/debug-springboot-trace.sh
@@ -12,8 +12,79 @@ PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 SERVER_DIR="$PROJECT_ROOT/server"
 
 cd "$SERVER_DIR" || { echo "Failed to change directory to server"; exit 1; }
-echo "[scripts/server/debug-springboot] Successfully moved to server directory."
-pwd
+echo "[scripts/server/debug-springboot] Successfully moved to server directory. $(pwd)"
 
-echo ">>> Running Spring Boot with TRACE logs..."
-./gradlew bootRun --args='--debug --trace --spring.main.banner-mode=console --spring.output.ansi.enabled=ALWAYS'
+# ===============================================================
+# Step 1. 8080 포트 점검
+# ===============================================================
+
+PORT=8080
+echo "[scripts/server/debug-springboot] Checking if port $PORT is already in use..."
+
+if lsof -i :$PORT >/dev/null 2>&1; then
+  echo "[scripts/server/debug-springboot] Port $PORT is already in use. Checking Spring Boot health..."
+
+  HEALTH=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$PORT/actuator/health)
+
+  if [ "$HEALTH" -eq 200 ]; then
+    echo "[scripts/server/debug-springboot] curl -v http://localhost:$PORT/actuator/health"
+    echo "[scripts/server/debug-springboot] 200 Success"
+    echo "[scripts/server/debug-springboot] You can check logs in server/boot.log"
+    exit 0
+  else
+    echo "[scripts/server/debug-springboot] Port $PORT is occupied, but health check failed. Killing existing process..."
+    PID=$(lsof -ti :$PORT)
+    kill -9 $PID
+    echo "[scripts/server/debug-springboot] Killed process on port $PORT (PID: $PID)"
+  fi
+else
+  echo "[scripts/server/debug-springboot] Port $PORT is free. Proceeding with build and run."
+fi
+
+# ===============================================================
+# Step 2. Spring Boot 빌드
+# ===============================================================
+
+echo "[scripts/server/debug-springboot] Building Spring Boot application..."
+./gradlew build -x test -Pprofile=local
+
+if [ $? -ne 0 ]; then
+  echo "[scripts/server/debug-springboot] Failed to build the Spring Boot application."
+  exit 1
+fi
+
+echo "[scripts/server/debug-springboot] Successfully built the Spring Boot application."
+
+# ===============================================================
+# Step 3. 서버 실행 (백그라운드)
+# ===============================================================
+
+echo "[scripts/server/debug-springboot] Starting Spring Boot application on port $PORT..."
+nohup ./gradlew bootRun \
+  --args='--debug --trace --spring.main.banner-mode=console --spring.output.ansi.enabled=ALWAYS' \
+  > boot.log 2>&1 &
+
+# 방금 백그라운드로 실행된 프로세스의 PID(Process ID)”를 변수에 저장하는 구문
+BOOT_PID=$!
+echo "[scripts/server/debug-springboot] BootRun process started (PID: $BOOT_PID)"
+
+# ===============================================================
+# Step 4. Health Check (최대 30초 대기)
+# ===============================================================
+echo "[scripts/server/debug-springboot] Waiting for server to start (checking /actuator/health)..."
+for i in {1..30}; do
+  HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/actuator/health")
+  if [ "$HEALTH" -eq 200 ]; then
+    echo "[scripts/server/debug-springboot] Server is UP (HTTP 200)"
+    echo "[scripts/server/debug-springboot] You can check detailed logs in $LOG_FILE"
+    exit 0
+  fi
+  sleep 1
+done
+
+# ===============================================================
+# Step 5. 실패 처리
+# ===============================================================
+echo "[scripts/server/debug-springboot] Server did not respond within 30 seconds."
+echo "[scripts/server/debug-springboot] Check server/boot.log for details."
+exit 1

--- a/scripts/server/run-springboot.sh
+++ b/scripts/server/run-springboot.sh
@@ -62,6 +62,7 @@ echo "[scripts/server/run-springboot] Successfully built the Spring Boot applica
 echo "[scripts/server/run-springboot] Starting Spring Boot application on port $PORT..."
 nohup ./gradlew bootRun --no-daemon > boot.log 2>&1 &
 
+# 방금 백그라운드로 실행된 프로세스의 PID(Process ID)”를 변수에 저장하는 구문
 BOOT_PID=$!
 echo "[scripts/server/run-springboot] BootRun process started (PID: $BOOT_PID)"
 
@@ -82,5 +83,6 @@ for i in {1..30}; do
 done
 
 echo "[scripts/server/run-springboot] Server did not respond within 30 seconds."
-echo "[scripts/server/run-springboot] Check logs or make debug-springboot for more details."
+echo "[scripts/server/debug-springboot] Check server/boot.log for details."
+echo "[scripts/server/run-springboot] If you need more detailed, try \"make debug-springboot\""
 exit 1


### PR DESCRIPTION
## 관련 이슈를 등록해주세요.
related to #1

<!-- 플랫폼: Web, App, Server, DevOps, AI -->

## 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 설명해주세요 -->
1. restart server make command 추가
2. debug-server script
- 서버 run(8080) 성공 테스트 구문 추가
- boot.log 기록 추가
3. mariaDB.sh에서, 성공(200)의 경우도 sleep 시간 부족으로 실패로 감지하는 이슈 수정
- 기존에 sleep 10으로 기다리던 것을 for 1..10로 수정하여 성공할 때까지 반복문을 돌리도록 변경 하였습니다.

<!-- 타입: bug | feature | refactor | docs | test | chore | deploy

## 스크린샷/영상
<!-- 변경사항을 보여주는 스크린샷이나 영상이 있다면 첨부해주세요 -->

## 체크리스트
- [x] 로컬 빌드 테스트 성공
- [x] 커밋 메시지 규칙 준수
- [x] 관련 이슈 연결